### PR TITLE
Add ensureUniqueBuildPath parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ The build directory.
 
 default: `.build` in the entry file directory
 
+### ensureUniqueBuildPath: boolean
+
+Control whether the build output is placed in a unique directory (sha256 hash) or not. This can be disabled to simplify development and debugging.
+
+default: true
+
 ### ...other options
 
 All other properties of lambda.Function are supported, see also the [AWS Lambda construct library](https://github.com/aws/aws-cdk/tree/master/packages/%40aws-cdk/aws-lambda).

--- a/lib/function.ts
+++ b/lib/function.ts
@@ -49,6 +49,13 @@ export interface WebpackFunctionProps extends FunctionOptions {
    * @default - `.build` in the entry file directory
    */
   readonly buildDir?: string;
+
+  /**
+   * Ensure a unique build path
+   *
+   * @default - true
+   */
+  readonly ensureUniqueBuildPath?: boolean;
 }
 
 export interface WebpackSingletonFunctionProps extends WebpackFunctionProps {
@@ -105,10 +112,8 @@ function preProcess(props: WebpackFunctionProps) {
   const handler = props.handler || "handler";
   const runtime = props.runtime || Runtime.NODEJS_12_X;
   const buildDir = props.buildDir || join(dirname(props.entry), ".build");
-  const handlerDir = join(
-    buildDir,
-    createHash("sha256").update(props.entry).digest("hex")
-  );
+  const ensureUniqueBuildPath = typeof props.ensureUniqueBuildPath === 'boolean' ? props.ensureUniqueBuildPath : true;
+  const handlerDir = ensureUniqueBuildPath ? createUniquePath(buildDir, props.entry) : buildDir;
   const outputBasename = basename(props.entry, extname(props.entry));
 
   // Build with webpack
@@ -119,4 +124,11 @@ function preProcess(props: WebpackFunctionProps) {
   });
   builder.build();
   return { runtime, handlerDir, outputBasename, handler };
+}
+
+function createUniquePath(buildDir: string, currentPath: string) {
+  return join(
+    buildDir,
+    createHash("sha256").update(currentPath).digest("hex")
+  );
 }


### PR DESCRIPTION
Hey thanks for the useful construct! I switched to this lib instead of NodeJsFunction because I needed `emitDecoratorMetadata` and `experimentalDecorator` tsconfig support which esbuild doesn't currently support.

I noticed when developing with WebpackFunction, the build paths were appended with a sha256 hash of the entry props directory. This is probably good for production (why I am leaving it the default), but it was causing some pain when setting up a webpack watcher for local development and lambda debugging. If we are able to control the exact location of the output, these pains go away.

I'd love to hear if there are other alternatives. If not, I hope this helps!
